### PR TITLE
Fix return type for NeopixelSetBufferLengthReq::getLen()

### DIFF
--- a/include/event.h
+++ b/include/event.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) Lawrence Lo (https://github.com/galliumstudio). 
+ * Copyright (C) Lawrence Lo (https://github.com/galliumstudio).
  * All rights reserved.
  *
  * This program is open source software: you can redistribute it and/or
@@ -54,11 +54,11 @@ enum {
     SYSTEM_POWER_SENSE_BLINK,
     SYSTEM_DONE,
     SYSTEM_FAIL,
-    
+
     USER_LED_TOGGLE_REQ,
-	
+
 	DELEGATE_PROCESS_COMMAND,
-	
+
 	I2C_SLAVE_START_REQ,
 	I2C_SLAVE_START_CFM,
 	I2C_SLAVE_STOP_REQ,
@@ -67,22 +67,22 @@ enum {
 	I2C_SLAVE_RECEIVE,
 	I2C_SLAVE_STOP_CONDITION,
 	I2C_SLAVE_TIMEOUT,
-	
+
 	SPI_SLAVE_START_REQ,
 	SPI_SLAVE_START_CFM,
 	SPI_SLAVE_STOP_REQ,
 	SPI_SLAVE_STOP_CFM,
 	SPI_SLAVE_REQUEST,
 	SPI_SLAVE_RECEIVE,
-	
+
 	DELEGATE_START_REQ,
 	DELEGATE_START_CFM,
 	DELEGATE_STOP_REQ,
 	DELEGATE_STOP_CFM,
 	DELEGATE_DATA_READY,
-	
+
 	GPIO_INTERRUPT_RECEIVED,
-    
+
 	ADC_START_REQ,
 	ADC_START_CFM,
 	ADC_STOP_REQ,
@@ -90,31 +90,31 @@ enum {
 	ADC_READ_REG_REQ,
 	ADC_WRITE_REG_REQ,
 	ADC_WRITE_WINMON_REQ,
-	
+
 	TIMER_START_REQ,
 	TIMER_START_CFM,
 	TIMER_STOP_REQ,
 	TIMER_STOP_CFM,
 	TIMER_WRITE_PWM,
 	TIMER_SET_FREQ,
-	
+
 	DAC_START_REQ,
 	DAC_START_CFM,
 	DAC_STOP_REQ,
 	DAC_STOP_CFM,
-	
+
 	USB_START_REQ,
 	USB_START_CFM,
 	USB_STOP_REQ,
 	USB_STOP_CFM,
-	
+
 	DAP_START_REQ,
 	DAP_START_CFM,
 	DAP_STOP_REQ,
 	DAP_STOP_CFM,
 	DAP_REQUEST,
 	DAP_READ,
-	
+
 	NEOPIXEL_START_REQ,
 	NEOPIXEL_START_CFM,
 	NEOPIXEL_STOP_REQ,
@@ -124,7 +124,7 @@ enum {
 	NEOPIXEL_SET_BUFFER_REQ,
 	NEOPIXEL_SET_BUFFER_LEN_REQ,
 	NEOPIXEL_SHOW_REQ,
-	
+
 	TOUCH_START_REQ,
     TOUCH_START_CFM,
     TOUCH_STOP_REQ,
@@ -137,7 +137,7 @@ enum {
 	INTERRUPT_STOP_CFM,
 	INTERRUPT_SET_REQ,
 	INTERRUPT_CLEAR_REQ,
-	
+
 	SERCOM_START_REQ,
 	SERCOM_START_CFM,
 	SERCOM_STOP_REQ,
@@ -156,7 +156,7 @@ enum {
 	KEYPAD_SYNC,
 	KEYPAD_WRITE_REG_REQ,
 	KEYPAD_READ_REG_REQ,
-	
+
 	ENCODER_START_REQ,
 	ENCODER_START_CFM,
 	ENCODER_STOP_REQ,
@@ -219,7 +219,7 @@ class DelegateProcessCommand : public Evt {
 	public:
 		DelegateProcessCommand(uint8_t requesterId, uint8_t highByte, uint8_t lowByte, uint8_t len, Fifo *fifo) :
 		Evt(DELEGATE_PROCESS_COMMAND), _requesterId(requesterId), _highByte(highByte), _lowByte(lowByte), _len(len), _fifo(fifo)  {}
-		
+
 		uint8_t getRequesterId() const { return _requesterId; }
 		uint8_t getHighByte() const { return _highByte; }
 		uint8_t getLowByte() const { return _lowByte; }
@@ -234,10 +234,10 @@ class DelegateDataReady : public Evt {
 	public:
 	DelegateDataReady(uint8_t requesterId)  :
 	Evt(DELEGATE_DATA_READY), _requesterId(requesterId), _fifo(NULL)  {}
-		
+
 	DelegateDataReady(uint8_t requesterId, Fifo *fifo) :
 	Evt(DELEGATE_DATA_READY), _requesterId(requesterId), _fifo(fifo)  {}
-	
+
 	uint8_t getRequesterId() const { return _requesterId; }
 	Fifo *getFifo() const { return _fifo; }
 	private:
@@ -275,11 +275,11 @@ class ADCReadRegReq : public Evt {
 	public:
 	ADCReadRegReq(uint8_t requesterId, uint8_t reg, Fifo *dest) :
 	Evt(ADC_READ_REG_REQ), _requesterId(requesterId), _reg(reg), _dest(dest) {}
-	
+
 	uint8_t getRequesterId() const { return _requesterId; }
 	uint8_t getReg() const { return _reg; }
 	Fifo *getDest() const { return _dest; }
-	
+
 	private:
 	uint8_t _requesterId, _reg;
 	Fifo *_dest;
@@ -289,22 +289,22 @@ class ADCWriteRegReq : public Evt {
 	public:
 	ADCWriteRegReq(uint8_t reg, uint8_t value) :
 	Evt(ADC_WRITE_REG_REQ), _reg(reg), _value(value) {}
-	
+
 	uint8_t getReg() const { return _reg; }
 	uint8_t getValue() const { return _value; }
-	
+
 	private:
 	uint8_t _reg, _value;
 };
 
 class ADCWriteWinmonThresh : public Evt {
 	public:
-	ADCWriteWinmonThresh(uint16_t upper, uint16_t lower) : 
+	ADCWriteWinmonThresh(uint16_t upper, uint16_t lower) :
 	Evt(ADC_WRITE_WINMON_REQ), _upper(upper), _lower(lower) {}
-		
+
 	uint16_t getUpper() const { return _upper; }
 	uint16_t getLower() const { return _lower; }
-		
+
 	private:
 	uint16_t _upper, _lower;
 };
@@ -327,10 +327,10 @@ class TimerWritePWM : public Evt {
 	public:
 	TimerWritePWM(uint8_t pwm, uint16_t value) :
 	Evt(TIMER_WRITE_PWM), _pwm(pwm), _value(value) {}
-		
+
 	uint8_t getPwm() const { return _pwm; }
 	uint16_t getValue() const { return _value; }
-		
+
 	private:
 	uint8_t _pwm;
 	uint16_t _value;
@@ -340,10 +340,10 @@ class TimerSetFreq : public Evt {
 	public:
 	TimerSetFreq(uint8_t pwm, uint16_t freq) :
 	Evt(TIMER_SET_FREQ), _pwm(pwm), _freq(freq) {}
-	
+
 	uint8_t getPwm() const { return _pwm; }
 	uint16_t getFreq() const { return _freq; }
-	
+
 	private:
 	uint8_t _pwm;
 	uint16_t _freq;
@@ -369,7 +369,7 @@ class USBStartReq : public Evt {
 	public:
 	USBStartReq(Fifo *outFifo, Fifo *inFifo) :
 	Evt(USB_START_REQ), _in_fifo(inFifo), _out_fifo(outFifo) {}
-	
+
 	Fifo *getInFifo() const { return _in_fifo; }
 	Fifo *getOutFifo() const { return _out_fifo; }
 	private:
@@ -395,7 +395,7 @@ class DAPStartReq : public Evt {
 	public:
 	DAPStartReq(Fifo *rxFifo) :
 	Evt(DAP_START_REQ), _rx_fifo(rxFifo) {}
-	
+
 	Fifo *getRxFifo() const { return _rx_fifo; }
 	private:
 	Fifo *_rx_fifo;
@@ -417,7 +417,7 @@ class DAPRequest : public Evt {
 	public:
 	DAPRequest(uint8_t requesterId, Fifo *source, uint8_t len) :
 	Evt(DAP_REQUEST), _requesterId(requesterId), _source(source), _len(len) {}
-	
+
 	uint8_t getRequesterId() const { return _requesterId; }
 	Fifo *getSource() const { return _source; }
 	uint8_t getLen() const { return _len; }
@@ -431,7 +431,7 @@ class DAPRead : public Evt {
 	public:
 	DAPRead(uint8_t requesterId) :
 	Evt(DAP_READ), _requesterId(requesterId) {}
-	
+
 	uint8_t getRequesterId() const { return _requesterId; }
 	private:
 	uint8_t _requesterId;
@@ -455,7 +455,7 @@ class NeopixelSetPinReq : public Evt {
 	public:
 	NeopixelSetPinReq(uint8_t pin) :
 	Evt(NEOPIXEL_SET_PIN_REQ), _pin(pin) {}
-	
+
 	uint8_t getPin() const { return _pin; }
 	private:
 	uint8_t _pin;
@@ -465,7 +465,7 @@ class NeopixelSetSpeedReq : public Evt {
 	public:
 	NeopixelSetSpeedReq(uint8_t speed) :
 	Evt(NEOPIXEL_SET_SPEED_REQ), _speed(speed) {}
-	
+
 	uint8_t getSpeed() const { return _speed; }
 	private:
 	uint8_t _speed;
@@ -475,17 +475,17 @@ class NeopixelSetBufferLengthReq : public Evt {
 	public:
 	NeopixelSetBufferLengthReq(uint16_t len) :
 	Evt(NEOPIXEL_SET_BUFFER_LEN_REQ), _len(len) {}
-	
-	uint8_t getLen() const { return _len; }
+
+	uint16_t getLen() const { return _len; }
 	private:
-	uint8_t _len;
+	uint16_t _len;
 };
 
 class NeopixelSetBufferReq : public Evt {
 	public:
 	NeopixelSetBufferReq(uint16_t addr, Fifo *source) :
 	Evt(NEOPIXEL_SET_BUFFER_REQ), _addr(addr), _source(source){}
-	
+
 	uint16_t getAddr() const { return _addr; }
 	Fifo *getSource() const { return _source; }
 	private:
@@ -537,19 +537,19 @@ class InterruptStopCfm : public ErrorEvt {
 
 class InterruptSetReq : public Evt {
 	public:
-	InterruptSetReq(uint32_t id) : 
+	InterruptSetReq(uint32_t id) :
 	Evt(INTERRUPT_SET_REQ), _id(id) {}
-	
+
 	uint32_t getId() const { return _id; }
 	private:
-	uint32_t _id;	
+	uint32_t _id;
 };
 
 class InterruptClearReq : public Evt {
 	public:
 	InterruptClearReq(uint32_t id) :
 	Evt(INTERRUPT_CLEAR_REQ), _id(id) {}
-	
+
 	uint32_t getId() const { return _id; }
 	private:
 	uint32_t _id;
@@ -561,7 +561,7 @@ class SercomStartReq : public Evt {
 	public:
 	SercomStartReq(Fifo *rxFifo) :
 	Evt(SERCOM_START_REQ), _rx_fifo(rxFifo) {}
-	
+
 	Fifo *getRxFifo() const { return _rx_fifo; }
 	private:
 	Fifo *_rx_fifo;
@@ -584,7 +584,7 @@ class SercomWriteDataReq : public Evt {
 	public:
 	SercomWriteDataReq(Fifo *source, uint8_t len) :
 	Evt(SERCOM_WRITE_DATA_REQ), _source(source), _len(len){}
-	
+
 	Fifo *getSource() const { return _source; }
 	uint8_t getLen() const { return _len; }
 	private:
@@ -594,37 +594,37 @@ class SercomWriteDataReq : public Evt {
 
 class SercomReadDataReq : public Evt {
 	public:
-	SercomReadDataReq(uint8_t requesterId) : 
+	SercomReadDataReq(uint8_t requesterId) :
 	Evt(SERCOM_READ_DATA_REQ), _requesterId(requesterId) {}
-		
+
 	uint8_t getRequesterId() const { return _requesterId; }
 	private:
 	uint8_t _requesterId;
-	
+
 };
 
 class SercomReadRegReq : public Evt {
 	public:
-	SercomReadRegReq(uint8_t requesterId, uint8_t reg, Fifo *dest) : 
+	SercomReadRegReq(uint8_t requesterId, uint8_t reg, Fifo *dest) :
 	Evt(SERCOM_READ_REG_REQ), _requesterId(requesterId), _reg(reg), _dest(dest) {}
-		
+
 	uint8_t getRequesterId() const { return _requesterId; }
 	uint8_t getReg() const { return _reg; }
 	Fifo *getDest() const { return _dest; }
-		
+
 	private:
 	uint8_t _requesterId, _reg;
-	Fifo *_dest;	
+	Fifo *_dest;
 };
 
 class SercomWriteRegReq : public Evt {
 	public:
 	SercomWriteRegReq(uint8_t reg, uint32_t value) :
 	Evt(SERCOM_WRITE_REG_REQ), _reg(reg), _value(value) {}
-	
+
 	uint8_t getReg() const { return _reg; }
 	uint32_t getValue() const { return _value; }
-	
+
 	private:
 	uint8_t _reg;
 	uint32_t _value;
@@ -636,7 +636,7 @@ class I2CSlaveStartReq : public Evt {
 	public:
 	I2CSlaveStartReq(Fifo *outFifo, Fifo *inFifo) :
 	Evt(I2C_SLAVE_START_REQ), _in_fifo(inFifo), _out_fifo(outFifo) {}
-	
+
 	Fifo *getInFifo() const { return _in_fifo; }
 	Fifo *getOutFifo() const { return _out_fifo; }
 	private:
@@ -660,11 +660,11 @@ class I2CSlaveReceive : public Evt {
 	public:
 	I2CSlaveReceive(uint8_t highByte, uint8_t lowByte, uint8_t len) :
 	Evt(I2C_SLAVE_RECEIVE), _highByte(highByte), _lowByte(lowByte), _len(len) {}
-		
+
 	uint8_t getHighByte() const { return _highByte; }
 	uint8_t getLowByte() const { return _lowByte; }
 	uint8_t getLen() const { return _len; }
-		
+
 	private:
 	uint8_t _highByte, _lowByte, _len;
 };
@@ -675,7 +675,7 @@ class KeypadStartReq : public Evt {
 	public:
 	KeypadStartReq(Fifo *fifo) :
 	Evt(KEYPAD_START_REQ), _fifo(fifo) {}
-	
+
 	Fifo *getFifo() const { return _fifo; }
 	private:
 	Fifo *_fifo;
@@ -697,10 +697,10 @@ class KeypadWriteRegReq : public Evt {
 	public:
 	KeypadWriteRegReq(uint8_t reg, uint32_t value) :
 	Evt(KEYPAD_WRITE_REG_REQ), _reg(reg), _value(value) {}
-	
+
 	uint8_t getReg() const { return _reg; }
 	uint32_t getValue() const { return _value; }
-	
+
 	private:
 	uint8_t _reg;
 	uint32_t _value;
@@ -708,13 +708,13 @@ class KeypadWriteRegReq : public Evt {
 
 class KeypadReadRegReq : public Evt {
 	public:
-	KeypadReadRegReq(uint8_t requesterId, uint8_t reg, Fifo *dest) : 
+	KeypadReadRegReq(uint8_t requesterId, uint8_t reg, Fifo *dest) :
 	Evt(KEYPAD_READ_REG_REQ), _requesterId(requesterId), _reg(reg), _dest(dest) {}
-		
+
 	uint8_t getRequesterId() const { return _requesterId; }
 	uint8_t getReg() const { return _reg; }
 	Fifo *getDest() const { return _dest; }
-		
+
 	private:
 	uint8_t _requesterId, _reg;
 	Fifo *_dest;
@@ -727,7 +727,7 @@ class SPISlaveStartReq : public Evt {
 	public:
 	SPISlaveStartReq(Fifo *outFifo, Fifo *inFifo) :
 	Evt(SPI_SLAVE_START_REQ), _in_fifo(inFifo), _out_fifo(outFifo) {}
-	
+
 	Fifo *getInFifo() const { return _in_fifo; }
 	Fifo *getOutFifo() const { return _out_fifo; }
 	private:
@@ -751,11 +751,11 @@ class SPISlaveReceive : public Evt {
 	public:
 	SPISlaveReceive(uint8_t highByte, uint8_t lowByte, uint8_t len) :
 	Evt(SPI_SLAVE_RECEIVE), _highByte(highByte), _lowByte(lowByte), _len(len) {}
-	
+
 	uint8_t getHighByte() const { return _highByte; }
 	uint8_t getLowByte() const { return _lowByte; }
 	uint8_t getLen() const { return _len; }
-	
+
 	private:
 	uint8_t _highByte, _lowByte, _len;
 };
@@ -776,13 +776,13 @@ class EncoderStopCfm : public ErrorEvt {
 
 class EncoderReadRegReq : public Evt {
 	public:
-	EncoderReadRegReq(uint8_t requesterId, uint8_t reg, Fifo *dest) : 
+	EncoderReadRegReq(uint8_t requesterId, uint8_t reg, Fifo *dest) :
 	Evt(ENCODER_READ_REG_REQ), _requesterId(requesterId), _reg(reg), _dest(dest) {}
-		
+
 	uint8_t getRequesterId() const { return _requesterId; }
 	uint8_t getReg() const { return _reg; }
 	Fifo *getDest() const { return _dest; }
-		
+
 	private:
 	uint8_t _requesterId, _reg;
 	Fifo *_dest;
@@ -793,10 +793,10 @@ class EncoderWriteRegReq : public Evt {
 	public:
 	EncoderWriteRegReq(uint8_t reg, int32_t value) :
 	Evt(ENCODER_WRITE_REG_REQ), _reg(reg), _value(value) {}
-	
+
 	uint8_t getReg() const { return _reg; }
 	int32_t getValue() const { return _value; }
-	
+
 	private:
 	uint8_t _reg;
 	int32_t _value;


### PR DESCRIPTION
Re this thread:
https://forums.adafruit.com/viewtopic.php?f=8&t=152524

Simple bug/fix. Just needed to change a `uint8_t` to `uint16_t`.