### PR TITLE
Change initialization to stop warning from occurring

### DIFF
--- a/bsp/bsp_dma.cpp
+++ b/bsp/bsp_dma.cpp
@@ -11,8 +11,8 @@
 #include "bsp_dma.h"
 
 __attribute__((__aligned__(16))) static DmacDescriptor // 128 bit alignment
-  _descriptor[DMAC_CH_NUM] SECTION_DMAC_DESCRIPTOR,
-  _writeback[DMAC_CH_NUM]  SECTION_DMAC_DESCRIPTOR;
+  _descriptor[DMAC_CH_NUM] SECTION_DMAC_DESCRIPTOR = {0},
+  _writeback[DMAC_CH_NUM]  SECTION_DMAC_DESCRIPTOR = {0};
 
 void dmac_init()
 {
@@ -27,8 +27,6 @@ void dmac_init()
     // Initialize descriptor list addresses
     DMAC->BASEADDR.bit.BASEADDR = (uint32_t)_descriptor;
     DMAC->WRBADDR.bit.WRBADDR   = (uint32_t)_writeback;
-    memset(_descriptor, 0, sizeof(_descriptor));
-    memset(_writeback , 0, sizeof(_writeback));
 
     // Re-enable DMA controller with all priority levels
     DMAC->CTRL.reg = DMAC_CTRL_DMAENABLE | DMAC_CTRL_LVLEN(0xF);


### PR DESCRIPTION
When compiling with the latest `arm-none-eabi-gcc` from [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) and compiling the soil sensor using `make BOARD=soil`  produces the error:

```
bsp/bsp_dma.cpp: In function 'void dmac_init()':
bsp/bsp_dma.cpp:30:47: error: 'void* memset(void*, int, size_t)' clearing an object of type 'struct DmacDescriptor' with no trivial copy-assignment; use value-initialization instead [-Werror=class-memaccess]
   30 |     memset(_descriptor, 0, sizeof(_descriptor));
      |                                               ^
In file included from lib/samd10/include/samd10d14am.h:224,
                 from lib/samd10/include/sam.h:42,
                 from bsp/bsp_dma.cpp:8:
lib/samd10/include/component/dmac.h:984:16: note: 'struct DmacDescriptor' declared here
  984 | typedef struct {
      |                ^
bsp/bsp_dma.cpp:31:46: error: 'void* memset(void*, int, size_t)' clearing an object of type 'struct DmacDescriptor' with no trivial copy-assignment; use value-initialization instead [-Werror=class-memaccess]
   31 |     memset(_writeback , 0, sizeof(_writeback));
      |                                              ^
In file included from lib/samd10/include/samd10d14am.h:224,
                 from lib/samd10/include/sam.h:42,
                 from bsp/bsp_dma.cpp:8:
lib/samd10/include/component/dmac.h:984:16: note: 'struct DmacDescriptor' declared here
  984 | typedef struct {
      |                ^
cc1plus: all warnings being treated as errors
make: *** [Makefile:185: build/soil/bsp/bsp_dma.o] Error 1
```

This fixes this warning by initializing the struct with zeros so there is no need to memset.