### PR TITLE
Do not re-enable the timer when the user request a PWM frequency of 0.

### DIFF
--- a/bsp/bsp_timer.cpp
+++ b/bsp/bsp_timer.cpp
@@ -119,7 +119,9 @@ void setFreq( uint8_t pwm, uint16_t freq )
         p.tc->COUNT16.CTRLA.bit.ENABLE = 0;
         syncTC_16(p.tc);
         p.tc->COUNT16.CTRLA.bit.PRESCALER = prescale;
-        enableTimer(p.tc);
+        if (freq > 0){
+          enableTimer(p.tc);
+        }
 #ifdef USE_TCC_TIMERS
     }
     else{


### PR DESCRIPTION
This is a tentative fix for for issue #55. I tested that this fix it on a SAMD10 chip (that, setting the PWM freq to 0 will now fully stop the PWM output). I did not test it on SAMD09 or SAMD21 chips (as I don’t have compatible hardware to test).

I’m not entirely convinced by this PR, because it might be more logical to stop the output with a call to setting the PMW value rather than the frequency. However, the current `PWMWrite` method in the firmware does not disable the PMW output (as opposed to the `setFreq` method that I’m changing), so this PR is a smaller change.