### PR TITLE
Enable link-time optimization for reduced code-size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,15 @@ CXXFLAGS = $(COMMON_FLAGS) \
 -ffunction-sections -fdata-sections \
 -fno-rtti -fno-exceptions -c -std=c++11 \
 -MD -MP -MF "$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$(@:%.o=%.o)" \
+-flto \
 $(WFLAGS)
 
 LDFLAGS= $(COMMON_FLAGS) \
 -Wall -Werror -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common \
 -Wl,--warn-section-align -Wl,--warn-unresolved-symbols \
 -save-temps \
---specs=nano.specs --specs=nosys.specs
+--specs=nano.specs --specs=nosys.specs \
+-flto
 BUILD_PATH=build/$(BOARD)
 
 QPPORT = lib/qp/ports/arm-cm/qxk/gnu


### PR DESCRIPTION
With link-time code optimization the linker can remove more dead code as it catches cases where code is not used across .obj boundaries. With this change Samd09breakout gets about 9% smaller code-size 16216 -> 14716 bytes, 1500 bytes smaller ~ 9% improvement!  This will allow squeezing-in additional functionality with custom configs, for example this allows enabling the rotary encoder module without going over the size limit.
I did manual testing through some basic functions after this change on samd09breakout with PWM, digital read working as expected. This should be a pretty safe change. First time contributing to this project, let me know if I am missing something?