### PR TITLE
Update build.yml to ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - name: Dump GitHub context
       env:


### PR DESCRIPTION
was using ubuntu-16.04, which was discontinued in September 2021.